### PR TITLE
Implement get roles endpoint

### DIFF
--- a/src/main/java/com/siemens/roleservice/controllers/RoleController.java
+++ b/src/main/java/com/siemens/roleservice/controllers/RoleController.java
@@ -1,0 +1,31 @@
+package com.siemens.roleservice.controllers;
+
+import com.siemens.roleservice.domain.dtos.RoleDto;
+import com.siemens.roleservice.domain.entities.RoleEntity;
+import com.siemens.roleservice.mappers.Mapper;
+import com.siemens.roleservice.services.RoleService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class RoleController {
+
+    private final RoleService roleService;
+    private final Mapper<RoleEntity, RoleDto> roleMapper;
+
+    public RoleController(RoleService roleService, Mapper<RoleEntity, RoleDto> roleMapper) {
+        this.roleService = roleService;
+        this.roleMapper = roleMapper;
+    }
+
+    @GetMapping("/roles")
+    public List<RoleDto> getRoles() {
+        List<RoleEntity> roles = roleService.findAll();
+        return roles.stream()
+                .map(roleMapper::mapTo)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/siemens/roleservice/domain/dtos/RoleDto.java
+++ b/src/main/java/com/siemens/roleservice/domain/dtos/RoleDto.java
@@ -1,0 +1,17 @@
+package com.siemens.roleservice.domain.dtos;
+
+import com.siemens.roleservice.domain.entities.PermissionEntity;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class RoleDto {
+    private String id;
+    private String name;
+    private Set<PermissionEntity> permissions;
+}

--- a/src/main/java/com/siemens/roleservice/domain/entities/RoleEntity.java
+++ b/src/main/java/com/siemens/roleservice/domain/entities/RoleEntity.java
@@ -4,9 +4,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Set;
 
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
 @Entity
 @Table(name = "role")
 public class RoleEntity {

--- a/src/main/java/com/siemens/roleservice/mappers/impl/RoleMapperImpl.java
+++ b/src/main/java/com/siemens/roleservice/mappers/impl/RoleMapperImpl.java
@@ -1,0 +1,26 @@
+package com.siemens.roleservice.mappers.impl;
+
+import com.siemens.roleservice.domain.dtos.RoleDto;
+import com.siemens.roleservice.domain.entities.RoleEntity;
+import com.siemens.roleservice.mappers.Mapper;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleMapperImpl implements Mapper<RoleEntity, RoleDto> {
+    private ModelMapper modelMapper;
+
+    public RoleMapperImpl(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    @Override
+    public RoleDto mapTo(RoleEntity roleEntity) {
+        return modelMapper.map(roleEntity, RoleDto.class);
+    }
+
+    @Override
+    public RoleEntity mapFrom(RoleDto roleDto) {
+        return modelMapper.map(roleDto, RoleEntity.class);
+    }
+}

--- a/src/main/java/com/siemens/roleservice/repositories/RoleRepository.java
+++ b/src/main/java/com/siemens/roleservice/repositories/RoleRepository.java
@@ -1,0 +1,9 @@
+package com.siemens.roleservice.repositories;
+
+import com.siemens.roleservice.domain.entities.RoleEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends CrudRepository<RoleEntity, String> {
+}

--- a/src/main/java/com/siemens/roleservice/services/RoleService.java
+++ b/src/main/java/com/siemens/roleservice/services/RoleService.java
@@ -1,0 +1,9 @@
+package com.siemens.roleservice.services;
+
+import com.siemens.roleservice.domain.entities.RoleEntity;
+
+import java.util.List;
+
+public interface RoleService {
+    List<RoleEntity> findAll();
+}

--- a/src/main/java/com/siemens/roleservice/services/impl/RoleServiceImpl.java
+++ b/src/main/java/com/siemens/roleservice/services/impl/RoleServiceImpl.java
@@ -1,0 +1,24 @@
+package com.siemens.roleservice.services.impl;
+
+import com.siemens.roleservice.domain.entities.RoleEntity;
+import com.siemens.roleservice.repositories.RoleRepository;
+import com.siemens.roleservice.services.RoleService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@Service
+public class RoleServiceImpl implements RoleService {
+    private RoleRepository roleRepository;
+
+    public RoleServiceImpl(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    @Override
+    public List<RoleEntity> findAll() {
+        return StreamSupport.stream(roleRepository.findAll().spliterator(), false).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/siemens/roleservice/controllers/RoleControllerTest.java
+++ b/src/test/java/com/siemens/roleservice/controllers/RoleControllerTest.java
@@ -1,0 +1,44 @@
+package com.siemens.roleservice.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureMockMvc
+public class RoleControllerTest {
+    private MockMvc mockMvc;
+
+    @Autowired
+    public RoleControllerTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Test
+    public void testGetRolesReturnsHttpStatus200() throws Exception {
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/roles")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    public void testGetRolesReturnsListOfRoles() throws Exception {
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/roles")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect((MockMvcResultMatchers.jsonPath("$[0].id").isString())
+        ).andExpect(MockMvcResultMatchers.jsonPath("$[0].id").value("9faaf9ba-464e-4c68-a901-630fc4de123b")
+        ).andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value("User"));
+    }
+}

--- a/src/test/java/com/siemens/roleservice/services/RoleServiceTest.java
+++ b/src/test/java/com/siemens/roleservice/services/RoleServiceTest.java
@@ -1,0 +1,36 @@
+package com.siemens.roleservice.services;
+
+import com.siemens.roleservice.domain.entities.RoleEntity;
+import com.siemens.roleservice.repositories.RoleRepository;
+import com.siemens.roleservice.services.impl.RoleServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RoleServiceTest {
+    @InjectMocks
+    private RoleServiceImpl roleService;
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Test
+    void testFindAll() {
+        RoleEntity roleEntity1 = RoleEntity.builder().id("123abc").name("user").build();
+        RoleEntity roleEntity2 = RoleEntity.builder().id("789xyz").name("administrator").build();
+        when(roleRepository.findAll()).thenReturn(List.of(roleEntity1, roleEntity2));
+
+        List<RoleEntity> roles = roleService.findAll();
+        assertEquals(roles.size(), 2);
+        assertEquals(roles.get(0), roleEntity1);
+        assertEquals(roles.get(1), roleEntity2);
+    }
+}


### PR DESCRIPTION
This adds an GET endpoint ("/roles") to fetch all roles. 

This includes
* REST controller 
* service 
* JPA repository
* object mapper
* unit tests and integration tests.